### PR TITLE
Perform the manifest attribute merge using a Map

### DIFF
--- a/src/main/scala/sk/vub/sbt/nifi/NarPlugin.scala
+++ b/src/main/scala/sk/vub/sbt/nifi/NarPlugin.scala
@@ -224,7 +224,7 @@ object NarPlugin extends AutoPlugin {
         ("Created-By", s"${BuildInfo.name}-${BuildInfo.version}")
       )
 
-      val mergeManifestAttributes = coreManifestAttributes.attributes ++ customManifestAttributes.flatMap(_.attributes)
+      val mergeManifestAttributes = coreManifestAttributes.attributes.toMap ++ customManifestAttributes.flatMap(_.attributes.toMap)
 
       write("MANIFEST.MF",
         mergeManifestAttributes.map(x => s"${x._1}: ${x._2}").mkString("\n") + "\n"


### PR DESCRIPTION
This PR is to enable the use of the sbt nar packager when creating a NiFi controller service.  In this use case the service implementation nar needs to specify the Nar-Dependency-Id, Nar-Dependency-Group and Nar-Dependency-Version manifest attributes for the service API.  Currently the Nar-Dependency-Version is hard-coded to the nifiVersion : while custom manifest attributes can be provided, they are appended to the end of the hard-coded list, meaning the Nar-Dependency-Version cannot be replaced.  This simple fix uses a Map to do the merge so that any custom manifest attributes replace hard-coded attributes with the same name. 